### PR TITLE
fix(test): exclude linked worktrees from discovery

### DIFF
--- a/src/__tests__/test-config.test.ts
+++ b/src/__tests__/test-config.test.ts
@@ -1,0 +1,15 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Vitest discovery isolation", () => {
+  it("excludes linked worktrees while preserving Vitest defaults", () => {
+    const configSource = fs.readFileSync(
+      path.join(process.cwd(), "vite.config.ts"),
+      "utf8",
+    );
+
+    expect(configSource).toContain("defaultExclude");
+    expect(configSource).toContain('"**/.worktrees/**"');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defaultExclude, defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
 
 export default defineConfig({
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: "jsdom",
+    exclude: [...defaultExclude, "**/.worktrees/**"],
     setupFiles: ["./src/setupTests.ts"],
     globals: true,
   },


### PR DESCRIPTION
## Summary

- exclude repository-linked `.worktrees` from Vitest discovery
- preserve Vitest's built-in exclusion patterns
- add a regression contract for the test configuration

## Motivation

After PR #56 was merged, running `npm run test` from the primary checkout discovered duplicate suites under `.worktrees`. Parallel preview lifecycle suites then competed for the same strict port and failed nondeterministically.

## Test plan

- [x] Regression test observed RED before the configuration change
- [x] Focused regression test passes
- [x] `npm run test` — 7 files, 81/81 tests
- [x] `npm run build:check`
- [x] `npm run preview:check`
- [x] port `49152` clear after verification
- [x] `git diff --check`
