### PR TITLE
ci: publish production deployment environment

### DIFF
--- a/.github/workflows/workers.yml
+++ b/.github/workflows/workers.yml
@@ -127,6 +127,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: validate
     runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://nurmi-dev.nurmi-vp.workers.dev/
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -62,6 +62,19 @@ The tag workflow verifies the tag format and ancestry, then creates a GitHub Rel
 
 ## GitHub configuration
 
+The production job targets the GitHub `production` environment and publishes the
+current Worker URL to the repository's Deployments view:
+
+- Environment: `production`
+- Current URL: `https://nurmi-dev.nurmi-vp.workers.dev/`
+- Final URL after cutover: `https://nurmi.dev/`
+
+Preview deployments are intentionally not registered as GitHub deployment
+environments. Their branch-specific URLs are published in the Actions run
+summary, while Cloudflare retains the deployed version history. This keeps the
+repository's deployment list focused on production instead of accumulating
+short-lived preview records.
+
 Repository-level Actions secrets:
 
 - `CLOUDFLARE_API_TOKEN` — Account → Workers Scripts → Edit/Write, scoped to the account containing `nurmi-dev`.


### PR DESCRIPTION
## Summary
- register the Cloudflare production job as GitHub environment `production`
- publish the current workers.dev URL in GitHub Deployments
- keep branch preview deployments in Actions summaries only

## Verification
- `npm test` — 91 tests passed
- `npm run build` — passed
- `npm run preview:check` — passed
- `wrangler deploy --dry-run` — passed
- workflow YAML parsed successfully
- `git diff --check` — passed