### PR TITLE
chore: remove GitHub Pages legacy configuration

### DIFF
--- a/.github/workflows/workers.yml
+++ b/.github/workflows/workers.yml
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: production
-      url: https://nurmi-dev.nurmi-vp.workers.dev/
+      url: https://nurmi.dev/
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -12,7 +12,7 @@ GitHub Actions owns validation and deployment. Cloudflare Workers Static Assets 
   - preview: `wrangler versions upload --preview-alias <branch-slug>`
   - production: `wrangler deploy`
 
-Cloudflare Git integration is not used. The current GitHub Pages deployment remains the fallback until the Worker production version and custom domain are verified.
+Cloudflare Git integration is not used. The Worker custom domain is the production endpoint; the historical GitHub Pages deployment is retained only as migration history until its repository setting and branch are removed.
 
 ## Branch workflow
 
@@ -80,10 +80,6 @@ Repository-level Actions secrets:
 - `CLOUDFLARE_API_TOKEN` — Account → Workers Scripts → Edit/Write, scoped to the account containing `nurmi-dev`.
 - `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account ID.
 
-Repository-level Actions variable:
-
-- `CLOUDFLARE_PAGES_PROJECT=nurmi-dev` — retained as the existing project identifier; `wrangler.jsonc` is authoritative for the Worker name.
-
 These are repository secrets, not Environment secrets. Do not expose them to pull request validation or commit them to the repository.
 
 SonarCloud is optional and remains skipped until both repository variables below are configured:
@@ -93,6 +89,6 @@ SonarCloud is optional and remains skipped until both repository variables below
 
 ## Cutover and rollback
 
-Do not change `nurmi.dev` until the Worker production deployment is verified through its `workers.dev` URL. Then add `nurmi.dev` as a Worker custom domain and verify DNS, TLS, assets, fonts, manifest, and application behavior.
+`nurmi.dev` is now attached to the `nurmi-dev` Worker as its production custom domain. The cutover was verified against the `workers.dev` artifact by checking DNS, TLS, HTML parity, assets, fonts, manifest, and application routes.
 
-Keep the GitHub Pages deployment available until the custom-domain check passes. For rollback, promote a known-good Worker version from Cloudflare's Deployments view and restore the previous DNS/custom-domain routing only if necessary. Do not rewrite release tags.
+For rollback, promote a known-good Worker version from Cloudflare's Deployments view and restore the previous DNS/custom-domain routing only if necessary. Do not rewrite release tags.

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,0 @@
-nurmi.dev


### PR DESCRIPTION
## Summary
- remove the legacy `public/CNAME` file
- remove obsolete GitHub Pages fallback wording from CI/CD docs
- document the completed Worker custom-domain cutover

The repository variable `CLOUDFLARE_PAGES_PROJECT` was removed separately after the Cloudflare cutover.

## Verification
- `npm test` — 91 tests passed
- `npm run build` — passed
- `npm run preview:check` — passed
- `git diff --check` — passed

## Cutover evidence
- `nurmi.dev` is attached to Worker `nurmi-dev`
- direct HTTPS verification returned HTTP 200
- HTML SHA-256 matched the verified `workers.dev` artifact