### PR TITLE
ci: skip previews for dependabot branches

### DIFF
--- a/.github/workflows/workers.yml
+++ b/.github/workflows/workers.yml
@@ -92,7 +92,10 @@ jobs:
 
   deploy-preview:
     name: deploy-preview
-    if: github.event_name == 'push' && github.ref != 'refs/heads/main'
+    if: >-
+      github.event_name == 'push' &&
+      github.ref != 'refs/heads/main' &&
+      !startsWith(github.ref, 'refs/heads/dependabot/')
     needs: validate
     runs-on: ubuntu-latest
     env:

--- a/tests/release-workflow-contract.test.ts
+++ b/tests/release-workflow-contract.test.ts
@@ -11,7 +11,7 @@ describe("production release workflow contract", () => {
   it("runs on every branch push while keeping pull requests validate-only", () => {
     expect(workflow).toContain("  push:\n    branches:\n      - '**'");
     expect(workflow).toContain(
-      "if: github.event_name == 'push' && github.ref != 'refs/heads/main'",
+      "    if: >-\n      github.event_name == 'push' &&\n      github.ref != 'refs/heads/main' &&\n      !startsWith(github.ref, 'refs/heads/dependabot/')",
     );
     expect(workflow).toContain("pull_request:\n    branches: [main]");
   });


### PR DESCRIPTION
## Summary
- prevent Cloudflare preview deploys from running on Dependabot branch pushes
- keep preview deployments enabled for normal non-main branch pushes
- avoid missing-secret failures because Dependabot workflows do not receive Cloudflare credentials

## Verification
- `workers.yml` YAML validation passed
- `git diff --check` passed
