### PR TITLE
ci: clean up closed PR preview deployments

### DIFF
--- a/.github/workflows/workers.yml
+++ b/.github/workflows/workers.yml
@@ -104,7 +104,7 @@ jobs:
       contents: read
       deployments: write
     environment:
-      name: preview-${{ github.ref_name }}
+      name: preview
       url: ${{ steps.preview.outputs.preview_url }}
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -189,7 +189,7 @@ jobs:
           script: |
             const branch = context.payload.pull_request.head.ref;
             const headOwner = context.payload.pull_request.head.repo?.owner.login;
-            const environment = `preview-${branch}`;
+            const environment = "preview";
 
             if (!headOwner) {
               core.info(`No head repository owner found for ${branch}; nothing to clean.`);

--- a/.github/workflows/workers.yml
+++ b/.github/workflows/workers.yml
@@ -3,6 +3,7 @@ name: Worker CI/CD
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, closed]
   push:
     branches:
       - '**'
@@ -21,6 +22,7 @@ env:
 jobs:
   validate:
     name: validate
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     runs-on: ubuntu-latest
     outputs:
       build_identity: ${{ steps.identity.outputs.build_identity }}
@@ -169,6 +171,75 @@ jobs:
             cat /tmp/wrangler-preview.log
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  cleanup-preview:
+    name: cleanup-preview
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+      pull-requests: read
+    steps:
+      - name: Remove closed pull request preview deployments
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const headOwner = context.payload.pull_request.head.repo?.owner.login;
+            const environment = `preview-${branch}`;
+
+            if (!headOwner) {
+              core.info(`No head repository owner found for ${branch}; nothing to clean.`);
+              return;
+            }
+
+            const openPullRequests = await github.paginate(
+              github.rest.pulls.list,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: "open",
+                head: `${headOwner}:${branch}`,
+                per_page: 100,
+              },
+            );
+            if (openPullRequests.length > 0) {
+              core.info(`Keeping ${environment}; another open PR still uses ${branch}.`);
+              return;
+            }
+
+            const deployments = await github.paginate(
+              github.rest.repos.listDeployments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                environment,
+                ref: branch,
+                per_page: 100,
+              },
+            );
+
+            for (const deployment of deployments) {
+              if (deployment.active) {
+                await github.rest.repos.createDeploymentStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  deployment_id: deployment.id,
+                  state: "inactive",
+                  environment,
+                  description: "Preview removed after pull request closure.",
+                });
+              }
+              await github.rest.repos.deleteDeployment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.id,
+              });
+            }
+            core.info(`Removed ${deployments.length} deployment(s) for ${environment}.`);
 
   deploy-production:
     name: deploy-production

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -41,7 +41,7 @@ ci-cd-canary
 → ci-cd-canary-nurmi-dev.nurmi-vp.workers.dev
 ```
 
-The workflow publishes the preview URL as a GitHub Deployment Environment URL. For a branch with an open pull request to `main`, GitHub exposes it in the PR's **Deployments** section as a clickable **View deployment** link. The same link is also available in the workflow run summary. A branch push without an associated PR still gets the deployment URL in the workflow run.
+The workflow publishes the preview URL as a GitHub Deployment Environment URL. For a branch with an open pull request to `main`, GitHub exposes it in the PR's **Deployments** section as a clickable **View deployment** link. The same link is also available in the workflow run summary. A branch push without an associated PR still gets the deployment URL in the workflow run. When the pull request closes, a cleanup job marks its preview deployments inactive and removes them from the deployment history. If another open pull request uses the same branch, cleanup is skipped.
 
 Preview deployment does not promote production.
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -41,7 +41,7 @@ ci-cd-canary
 → ci-cd-canary-nurmi-dev.nurmi-vp.workers.dev
 ```
 
-The workflow publishes the preview URL as a GitHub Deployment Environment URL. For a branch with an open pull request to `main`, GitHub exposes it in the PR's **Deployments** section as a clickable **View deployment** link. The same link is also available in the workflow run summary. A branch push without an associated PR still gets the deployment URL in the workflow run. When the pull request closes, a cleanup job marks its preview deployments inactive and removes them from the deployment history. If another open pull request uses the same branch, cleanup is skipped.
+The workflow publishes each preview URL through the shared GitHub Deployment Environment `preview`. For a branch with an open pull request to `main`, GitHub exposes the branch's deployment in the PR's **Deployments** section as a clickable **View deployment** link. The same link is also available in the workflow run summary. A branch push without an associated PR still gets the deployment URL in the workflow run. When the pull request closes, a cleanup job marks that branch's preview deployments inactive and removes them from the deployment history. If another open pull request uses the same branch, cleanup is skipped.
 
 Preview deployment does not promote production.
 

--- a/tests/release-workflow-contract.test.ts
+++ b/tests/release-workflow-contract.test.ts
@@ -34,7 +34,7 @@ describe("production release workflow contract", () => {
 
   it("publishes the preview URL as a GitHub deployment environment link", () => {
     expect(workflow).toContain("deployments: write");
-    expect(workflow).toContain("name: preview-${{ github.ref_name }}");
+    expect(workflow).toContain("name: preview");
     expect(workflow).toContain("url: ${{ steps.preview.outputs.preview_url }}");
     expect(workflow).toContain("id: preview");
     expect(workflow).toContain('echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"');

--- a/tests/release-workflow-contract.test.ts
+++ b/tests/release-workflow-contract.test.ts
@@ -13,7 +13,9 @@ describe("production release workflow contract", () => {
     expect(workflow).toContain(
       "    if: >-\n      github.event_name == 'push' &&\n      github.ref != 'refs/heads/main' &&\n      !startsWith(github.ref, 'refs/heads/dependabot/')",
     );
-    expect(workflow).toContain("pull_request:\n    branches: [main]");
+    expect(workflow).toContain(
+      "pull_request:\n    branches: [main]\n    types: [opened, synchronize, reopened, closed]",
+    );
   });
 
   it("serializes main runs without cancellation", () => {
@@ -36,6 +38,15 @@ describe("production release workflow contract", () => {
     expect(workflow).toContain("url: ${{ steps.preview.outputs.preview_url }}");
     expect(workflow).toContain("id: preview");
     expect(workflow).toContain('echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"');
+  });
+
+  it("removes closed pull request preview deployments", () => {
+    expect(workflow).toContain("cleanup-preview:");
+    expect(workflow).toContain("github.event.action == 'closed'");
+    expect(workflow).toContain("repos.listDeployments");
+    expect(workflow).toContain("repos.createDeploymentStatus");
+    expect(workflow).toContain("state: \"inactive\"");
+    expect(workflow).toContain("repos.deleteDeployment");
   });
 
   it("creates the tag only after successful deployment", () => {


### PR DESCRIPTION
## Summary
- trigger the workflow on pull request closure
- remove the closed PR branch preview deployments after marking them inactive
- preserve the preview when another open PR still uses the same branch
- document the cleanup behavior

## Verification
- `npm test` — 108 tests passed
- workflow YAML validation — passed
- `git diff --check` — passed

The existing merged PR #75 preview deployment was also cleaned up manually; its deployment list is now empty.