### PR TITLE
docs: document Cloudflare as the production host

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ merge to main → CI → Worker production deployment
 successful main deployment → next vX.Y.Z tag → GitHub Release
 ```
 
+### Hosting
+
+Production is served only through Cloudflare Workers at [nurmi.dev](https://nurmi.dev).
+GitHub Pages is intentionally disabled for this repository; do not enable a Pages
+publishing source in repository settings.
+
 ### Artifact ownership
 
 `dist/` is a **generated artifact**. It lives in `.gitignore` and is regenerated on demand


### PR DESCRIPTION
## Summary
- document Cloudflare Workers as the only production host
- record that GitHub Pages is intentionally disabled

## Purpose
This is intentionally a documentation-only change. After merge, verify that the main push does not re-enable GitHub Pages or create a `pages build and deployment` run.

## Verification
- `git diff --check` — passed