### PR TITLE
chore: update repository release links

### DIFF
--- a/src/__tests__/footer.test.tsx
+++ b/src/__tests__/footer.test.tsx
@@ -20,7 +20,7 @@ describe("build identity footer", () => {
     expect(footer).toHaveTextContent("Version v1.2.3");
     expect(releaseLink).toHaveAttribute(
       "href",
-      "https://github.com/nurvel/nurvel.github.io/releases",
+      "https://github.com/nurvel/nurmi-dev/releases",
     );
     expect(releaseLink).toHaveAttribute("target", "_blank");
     expect(releaseLink).toHaveAttribute("rel", "noopener noreferrer");

--- a/src/releaseIdentity.ts
+++ b/src/releaseIdentity.ts
@@ -1,5 +1,5 @@
 export const RELEASES_URL =
-  "https://github.com/nurvel/nurvel.github.io/releases";
+  "https://github.com/nurvel/nurmi-dev/releases";
 
 const STABLE_TAG_PATTERN = /^v\d+\.\d+\.\d+$/;
 


### PR DESCRIPTION
## Summary
- update the release link to the renamed `nurvel/nurmi-dev` repository
- keep the footer release-link contract aligned

## Verification
- `npm test` — 108 tests passed
- `git diff --check` — passed

## Rename follow-up
GitHub Pages is currently still configured on the renamed repository. Do not merge this PR until Pages is disabled in `Settings → Pages` and the Pages API returns 404.