### PR TITLE
fix: use bundler module resolution for TypeScript 7

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary
- switch TypeScript module resolution from removed node10 mode to bundler mode
- keep the existing Vite/ESM configuration compatible with TypeScript 7

## Validation
- npm ci --ignore-scripts
- npm run build:check
- npm test (108 tests)

This is the compatibility fix needed before Dependabot PR #82 can merge.